### PR TITLE
fix: create elasticsearch pvc only if fulltextsearch is enabled

### DIFF
--- a/nextcloud-aio-helm-chart/templates/nextcloud-aio-elasticsearch-persistentvolumeclaim.yaml
+++ b/nextcloud-aio-helm-chart/templates/nextcloud-aio-elasticsearch-persistentvolumeclaim.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.FULLTEXTSEARCH_ENABLED "yes" }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -14,3 +15,4 @@ spec:
   resources:
     requests:
       storage: {{ .Values.ELASTICSEARCH_STORAGE_SIZE }}
+{{- end }}


### PR DESCRIPTION
At the moment, this chart is creating elasticsearch pvc even if we don't need it.